### PR TITLE
release: v0.28.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,7 +688,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "forc-explore"
-version = "0.24.5"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "clap 3.2.22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forc-explore"
-version = "0.24.5"
+version = "0.28.1"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 edition = "2021"
 homepage = "https://fuel.network/"


### PR DESCRIPTION
bump version of `forc-explore` to match current versions of `forc` binaries in the sway repo.

depends on:
- [x] #9 